### PR TITLE
Added: load(identifiers:) method

### DIFF
--- a/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/RoomDriverTest.kt
+++ b/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/RoomDriverTest.kt
@@ -43,6 +43,18 @@ class RoomDriverTest  {
     }
 
     @Test
+    fun loadWithIDs_shouldReturnMultipleRecordsIfFound() {
+        val records = driver.db.queries().load(listOf("todo-1", "todo-3", "todo-5"))
+        assertEquals(records.size, 3)
+
+        records.forEachIndexed { index, record ->
+            val todoItemIndex = (index * 2) + 1
+            assertEquals("todo-$todoItemIndex", record.identifier)
+            assertEquals("todo-item-$todoItemIndex", String(record.content))
+        }
+    }
+
+    @Test
     fun load_shouldReturnEmptyArrayIfNotExists() {
         val records = driver.db.queries().load("not-existing-todo")
         assertEquals(0, records.size)

--- a/android/persistkit/src/main/java/co/omise/persistkit/BasicDatabase.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/BasicDatabase.kt
@@ -4,7 +4,7 @@ import co.omise.persistkit.driver.Driver
 import org.apache.commons.lang3.SerializationUtils
 import java.io.Serializable
 
-open class BasicDatabase(private val driver: Driver): Database {
+open class BasicDatabase(private val driver: Driver) : Database {
     override fun <T> loadAll(): List<T> where T : Identifiable, T : Serializable {
         return driver.query(Command.LoadAll)
             .map { decode<T>(it) }
@@ -14,6 +14,11 @@ open class BasicDatabase(private val driver: Driver): Database {
         return driver.query(Command.Load(identifier))
             .map { decode<T>(it) }
             .first()
+    }
+
+    override fun <T> load(identifiers: List<String>): List<T> where T : Identifiable, T : Serializable {
+        return driver.query(Command.LoadWithIDs(identifiers))
+            .map { decode<T>(it) }
     }
 
     override fun <T> save(obj: T) where T : Identifiable, T : Serializable {

--- a/android/persistkit/src/main/java/co/omise/persistkit/Command.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/Command.kt
@@ -3,6 +3,7 @@ package co.omise.persistkit
 sealed class Command {
     object LoadAll : Command()
     class Load(val identifier: String) : Command()
+    class LoadWithIDs(val identifiers: List<String>) : Command()
     class Save(val record: Record) : Command()
     class Delete(val identifier: String) : Command()
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/Database.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/Database.kt
@@ -9,6 +9,8 @@ interface Database {
 
     fun <T> load(identifier: String): T where T : Identifiable, T : Serializable
 
+    fun <T> load(identifiers: List<String>): List<T> where T : Identifiable, T : Serializable
+
     fun <T> save(obj: T) where T : Identifiable, T : Serializable
 
     fun delete(identifier: String): Boolean

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/room/Queries.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/room/Queries.kt
@@ -16,6 +16,9 @@ interface Queries {
     @Query("SELECT * FROM records WHERE _id = :identifier;")
     fun load(identifier: String): List<Record>
 
+    @Query("SELECT * FROM records WHERE _id IN(:identifiers);")
+    fun load(identifiers: List<String>): List<Record>
+
     // NOTE: REPLACE Strategy would make `loadAll` inconsistence
     // since it's create new row instead of update.
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
@@ -18,6 +18,7 @@ class RoomDriver(context: Context, filename: String) : Driver, ContextWrapper(co
         return when (command) {
             is Command.LoadAll -> db.queries().loadAll()
             is Command.Load -> db.queries().load(command.identifier)
+            is Command.LoadWithIDs -> db.queries().load(command.identifiers)
             else -> throw UnsupportedCommandException(command)
         }
     }
@@ -26,6 +27,7 @@ class RoomDriver(context: Context, filename: String) : Driver, ContextWrapper(co
         return when (command) {
             is Command.LoadAll -> db.queries().loadAll().size
             is Command.Load -> db.queries().load(command.identifier).size
+            is Command.LoadWithIDs -> db.queries().load(command.identifiers).size
             is Command.Delete -> db.queries().delete(command.identifier)
             is Command.Save -> {
                 db.queries().save(command.record)


### PR DESCRIPTION
This PR adds a new method called `load(identifiers:)` which will let the developer to load records with the identifier in the given list at once.

This method should help the developer on the performance since it helps developer to avoid `for loop loading` approach