### PR TITLE
Added: Delete database method

### DIFF
--- a/android/.idea/vcs.xml
+++ b/android/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/DatabaseTest.kt
+++ b/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/DatabaseTest.kt
@@ -96,6 +96,19 @@ class DatabaseTest {
         assertEquals("todo-1", updatedTodo.identifier)
         assertEquals(todo.detail, updatedTodo.detail)
     }
+
+    @Test
+    fun deleteDatabase_shouldLeaveNoFile() {
+        val context = InstrumentationRegistry.getContext()
+        val filename = "room-driver-test.sqlite3"
+        val databaseFilePath = context.getDatabasePath(filename)
+        assertTrue(databaseFilePath.exists())
+        assertTrue(database.deleteDatabase())
+        assertFalse(databaseFilePath.exists())
+        // Restore the database state
+        val driver = RoomDriver(context, filename)
+        database = BasicDatabase(driver)
+    }
 }
 
 

--- a/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/DatabaseTest.kt
+++ b/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/DatabaseTest.kt
@@ -1,0 +1,105 @@
+package co.omise.persistkit.driver.room
+
+import androidx.test.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import co.omise.persistkit.BasicDatabase
+import co.omise.persistkit.Identifiable
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.Serializable
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class DatabaseTest  {
+    private lateinit var database: BasicDatabase
+    private val todos: List<Todo> by lazy { (1..20).map { Todo("todo-$it", "todo-item-$it", this.date) } }
+    private val date = Date()
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getContext()
+        val driver = RoomDriver(context, "room-driver-test.sqlite3")
+        database = BasicDatabase(driver)
+
+        for (todo in todos) {
+            database.save(todo)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        database.deleteDatabase()
+    }
+
+    @Test
+    fun loadAll_shouldRetrieveAllRecord() {
+        val storedRecords = database.loadAll<Todo>()
+        assertEquals(todos.size, storedRecords.size)
+    }
+
+    @Test
+    fun load_shouldReturnSingleRecordIfFound() {
+        val todo = database.load<Todo>("todo-1")
+        assertNotNull(todo)
+
+        val record = todo ?: return
+
+        assertEquals("todo-1", record.identifier)
+        assertEquals("todo-item-1", record.detail)
+        assertEquals(date, record.dueDate)
+
+        val todoItem10 = database.load<Todo>("todo-10")
+        assertNotNull(todoItem10)
+
+        val recordOfItem10 = todoItem10 ?: return
+
+        assertEquals("todo-10", recordOfItem10.identifier)
+        assertEquals("todo-item-10", recordOfItem10.detail)
+        assertEquals(date, recordOfItem10.dueDate)
+    }
+
+    @Test
+    fun loadWithIDs_shouldReturnMultipleRecordsIfFound() {
+        val ids = listOf("todo-3", "todo-1", "todo-5")
+        val todos = database.load<Todo>(ids)
+        assertEquals(todos.size, 3)
+
+        ids.zip(todos).forEach {
+            val id = it.first
+            val todo = it.second
+            assertEquals(id, todo.identifier)
+        }
+    }
+
+    @Test
+    fun load_shouldReturnEmptyArrayIfNotExists() {
+        val todos = database.load<Todo>("not-existing-todo")
+        assertNull(todos)
+    }
+
+    @Test
+    fun save_shouldReplaceContentIfAlreadyExist() {
+        val record = database.load<Todo>("todo-1")
+        assertNotNull(record)
+        val todo = record ?: return
+        todo.detail = "foobar"
+        database.save(todo)
+
+        val updatedRecord = database.load<Todo>("todo-1")
+        assertNotNull(updatedRecord)
+        val updatedTodo = updatedRecord ?: return
+
+        assertEquals("todo-1", updatedTodo.identifier)
+        assertEquals(todo.detail, updatedTodo.detail)
+    }
+}
+
+
+data class Todo(val title: String, var detail: String, var dueDate: Date) : Serializable, Identifiable {
+    override val identifier: String
+        get() = title
+}
+

--- a/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/DatabaseTest.kt
+++ b/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/DatabaseTest.kt
@@ -13,7 +13,7 @@ import java.io.Serializable
 import java.util.*
 
 @RunWith(AndroidJUnit4::class)
-class DatabaseTest  {
+class DatabaseTest {
     private lateinit var database: BasicDatabase
     private val todos: List<Todo> by lazy { (1..20).map { Todo("todo-$it", "todo-item-$it", this.date) } }
     private val date = Date()
@@ -23,6 +23,7 @@ class DatabaseTest  {
         val context = InstrumentationRegistry.getContext()
         val driver = RoomDriver(context, "room-driver-test.sqlite3")
         database = BasicDatabase(driver)
+        database.clearDatabase()
 
         for (todo in todos) {
             database.save(todo)

--- a/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/RoomDriverTest.kt
+++ b/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/RoomDriverTest.kt
@@ -4,6 +4,7 @@ import androidx.test.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
 import co.omise.persistkit.Command
 import co.omise.persistkit.Record
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -19,11 +20,15 @@ class RoomDriverTest  {
     fun setUp() {
         val context = InstrumentationRegistry.getContext();
         driver = RoomDriver(context, "room-driver-test.sqlite3")
-        driver.deleteAll()
 
         for (record in records) {
             driver.execute(Command.Save(record))
         }
+    }
+
+    @After
+    fun tearDown() {
+        driver.deleteDatabase()
     }
 
     @Test
@@ -44,7 +49,7 @@ class RoomDriverTest  {
 
     @Test
     fun loadWithIDs_shouldReturnMultipleRecordsIfFound() {
-        val records = driver.db.queries().load(listOf("todo-1", "todo-3", "todo-5"))
+        val records = driver.db.queries().load(listOf("todo-3", "todo-1", "todo-5"))
         assertEquals(records.size, 3)
 
         records.forEachIndexed { index, record ->

--- a/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/RoomDriverTest.kt
+++ b/android/persistkit/src/androidTest/java/co/omise/persistkit/driver/room/RoomDriverTest.kt
@@ -12,14 +12,24 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class RoomDriverTest  {
+class RoomDriverTest {
     private lateinit var driver: RoomDriver
-    private val records: List<Record> by lazy { (1..20).map { Record("todo-$it", "kind", 0, "todo-item-$it".toByteArray()) } }
+    private val records: List<Record> by lazy {
+        (1..20).map {
+            Record(
+                "todo-$it",
+                "kind",
+                0,
+                "todo-item-$it".toByteArray()
+            )
+        }
+    }
 
     @Before
     fun setUp() {
         val context = InstrumentationRegistry.getContext();
         driver = RoomDriver(context, "room-driver-test.sqlite3")
+        driver.clearDatabase()
 
         for (record in records) {
             driver.execute(Command.Save(record))

--- a/android/persistkit/src/main/java/co/omise/persistkit/BasicDatabase.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/BasicDatabase.kt
@@ -19,6 +19,7 @@ open class BasicDatabase(private val driver: Driver) : Database {
     override fun <T> load(identifiers: List<String>): List<T> where T : Identifiable, T : Serializable {
         return driver.query(Command.LoadWithIDs(identifiers))
             .map { decode<T>(it) }
+            .sortedBy { identifiers.indexOf(it.identifier) }
     }
 
     override fun <T> save(obj: T) where T : Identifiable, T : Serializable {
@@ -36,5 +37,9 @@ open class BasicDatabase(private val driver: Driver) : Database {
     protected open fun <T> encode(obj: T): Record where T : Identifiable, T : Serializable {
         val content = SerializationUtils.serialize(obj)
         return Record(obj.identifier, obj::class.java.simpleName, 0, content)
+    }
+
+    override fun deleteDatabase(): Boolean {
+        return driver.deleteDatabase()
     }
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/BasicDatabase.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/BasicDatabase.kt
@@ -42,4 +42,8 @@ open class BasicDatabase(private val driver: Driver) : Database {
     override fun deleteDatabase(): Boolean {
         return driver.deleteDatabase()
     }
+
+    override fun clearDatabase() {
+        driver.clearDatabase()
+    }
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/Crypter.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/Crypter.kt
@@ -3,12 +3,12 @@ package co.omise.persistkit
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import androidx.annotation.VisibleForTesting
+import java.security.Key
 import java.security.KeyStore
 import java.security.UnrecoverableKeyException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.spec.GCMParameterSpec
-import java.security.Key
 
 private const val ANDROID_KEY_STORE = "AndroidKeyStore"
 private const val TRANSFORMATION_SYMMETRIC = "AES/GCM/NoPadding"
@@ -45,11 +45,12 @@ open class Crypter(private val aliasKeyName: String) {
             return
         }
         val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE)
-        val keySpec = KeyGenParameterSpec.Builder(aliasKeyName, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
-            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-            .setRandomizedEncryptionRequired(false)
-            .build()
+        val keySpec =
+            KeyGenParameterSpec.Builder(aliasKeyName, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(false)
+                .build()
         keyGenerator.init(keySpec)
         keyGenerator.generateKey()
         forceCreateKeyStore = false
@@ -65,7 +66,7 @@ open class Crypter(private val aliasKeyName: String) {
         return cipher.doFinal(plainData)
     }
 
-    open fun decrypt(encryptedBytes: ByteArray): ByteArray{
+    open fun decrypt(encryptedBytes: ByteArray): ByteArray {
         cipher.init(Cipher.DECRYPT_MODE, key, parameterSpec)
         val decryptedBytes = cipher.doFinal(encryptedBytes)
         return decryptedBytes

--- a/android/persistkit/src/main/java/co/omise/persistkit/Database.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/Database.kt
@@ -14,4 +14,6 @@ interface Database {
     fun delete(identifier: String): Boolean
 
     fun deleteDatabase(): Boolean
+
+    fun clearDatabase()
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/Database.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/Database.kt
@@ -1,7 +1,5 @@
 package co.omise.persistkit
 
-import co.omise.persistkit.driver.Driver
-import org.apache.commons.lang3.SerializationUtils
 import java.io.Serializable
 
 interface Database {
@@ -14,4 +12,6 @@ interface Database {
     fun <T> save(obj: T) where T : Identifiable, T : Serializable
 
     fun delete(identifier: String): Boolean
+
+    fun deleteDatabase(): Boolean
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/EncryptedDatabase.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/EncryptedDatabase.kt
@@ -3,7 +3,8 @@ package co.omise.persistkit
 import co.omise.persistkit.driver.Driver
 import java.io.Serializable
 
-class EncryptedDatabase(private val driver: Driver, private val aliasKeyName: String): BasicDatabase(driver), Database {
+class EncryptedDatabase(private val driver: Driver, private val aliasKeyName: String) : BasicDatabase(driver),
+    Database {
     private val crypter = Crypter(aliasKeyName)
 
     override fun <T> decode(rec: Record): T where T : Identifiable, T : Serializable {

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/Driver.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/Driver.kt
@@ -11,5 +11,7 @@ interface Driver {
     @Throws(UnsupportedCommandException::class)
     fun execute(command: Command): Int
 
-    fun deleteDatabase() : Boolean
+    fun clearDatabase()
+
+    fun deleteDatabase(): Boolean
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/Driver.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/Driver.kt
@@ -5,9 +5,11 @@ import co.omise.persistkit.Record
 import co.omise.persistkit.driver.exception.UnsupportedCommandException
 
 interface Driver {
-    @Throws (UnsupportedCommandException::class)
+    @Throws(UnsupportedCommandException::class)
     fun query(command: Command): List<Record>
 
-    @Throws (UnsupportedCommandException::class)
+    @Throws(UnsupportedCommandException::class)
     fun execute(command: Command): Int
+
+    fun deleteDatabase() : Boolean
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/room/Queries.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/room/Queries.kt
@@ -1,6 +1,5 @@
 package co.omise.persistkit.driver.room
 
-import androidx.annotation.VisibleForTesting
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/room/Queries.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/room/Queries.kt
@@ -16,7 +16,7 @@ interface Queries {
     @Query("SELECT * FROM records WHERE _id = :identifier;")
     fun load(identifier: String): List<Record>
 
-    @Query("SELECT * FROM records WHERE _id IN(:identifiers);")
+    @Query("SELECT * FROM records WHERE _id IN (:identifiers);")
     fun load(identifiers: List<String>): List<Record>
 
     // NOTE: REPLACE Strategy would make `loadAll` inconsistence
@@ -28,6 +28,5 @@ interface Queries {
     fun delete(identifier: String): Int
 
     @Query("DELETE FROM records")
-    @VisibleForTesting
     fun deleteAll()
 }

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
@@ -39,8 +39,15 @@ class RoomDriver(private val context: Context, private val filename: String) : D
         }
     }
 
-    override fun deleteDatabase(): Boolean {
+    override fun clearDatabase() {
         db.queries().deleteAll()
+    }
+
+    override fun deleteDatabase(): Boolean {
+        clearDatabase()
+        if (db.isOpen) {
+            db.close()
+        }
         return file.delete()
     }
 

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
@@ -44,7 +44,6 @@ class RoomDriver(private val context: Context, private val filename: String) : D
     }
 
     override fun deleteDatabase(): Boolean {
-        clearDatabase()
         if (db.isOpen) {
             db.close()
         }

--- a/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
+++ b/android/persistkit/src/main/java/co/omise/persistkit/driver/room/RoomDriver.kt
@@ -3,22 +3,25 @@ package co.omise.persistkit.driver.room;
 import android.content.Context
 import android.content.ContextWrapper
 import androidx.room.Room
-import co.omise.persistkit.Command;
+import co.omise.persistkit.Command
 import co.omise.persistkit.Record
 import co.omise.persistkit.driver.Driver
 import co.omise.persistkit.driver.exception.UnsupportedCommandException
-import org.jetbrains.annotations.TestOnly
+import java.io.File
 
 
-class RoomDriver(context: Context, filename: String) : Driver, ContextWrapper(context) {
+class RoomDriver(private val context: Context, private val filename: String) : Driver, ContextWrapper(context) {
     val db: KVDatabase = Room.databaseBuilder(context, KVDatabase::class.java, filename)
         .build()
+
+    private val file: File
+        get() = context.getDatabasePath(filename)
 
     override fun query(command: Command): List<Record> {
         return when (command) {
             is Command.LoadAll -> db.queries().loadAll()
             is Command.Load -> db.queries().load(command.identifier)
-            is Command.LoadWithIDs -> db.queries().load(command.identifiers)
+            is Command.LoadWithIDs -> db.queries().load(command.identifiers).sortedBy { command.identifiers.indexOf(it.identifier) }
             else -> throw UnsupportedCommandException(command)
         }
     }
@@ -36,8 +39,9 @@ class RoomDriver(context: Context, filename: String) : Driver, ContextWrapper(co
         }
     }
 
-    @TestOnly
-    fun deleteAll() {
+    override fun deleteDatabase(): Boolean {
         db.queries().deleteAll()
+        return file.delete()
     }
+
 }

--- a/ios/PersistKit.xcodeproj/xcshareddata/xcschemes/PersistKit.xcscheme
+++ b/ios/PersistKit.xcodeproj/xcshareddata/xcschemes/PersistKit.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2253925621A2ED9A00091822"
+               BuildableName = "PersistKit.framework"
+               BlueprintName = "PersistKit"
+               ReferencedContainer = "container:PersistKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8A4E61ED225C9ADE00C4174A"
+               BuildableName = "PersistKitTests.xctest"
+               BlueprintName = "PersistKitTests"
+               ReferencedContainer = "container:PersistKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8A4E61ED225C9ADE00C4174A"
+               BuildableName = "PersistKitTests.xctest"
+               BlueprintName = "PersistKitTests"
+               ReferencedContainer = "container:PersistKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2253925621A2ED9A00091822"
+            BuildableName = "PersistKit.framework"
+            BlueprintName = "PersistKit"
+            ReferencedContainer = "container:PersistKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2253925621A2ED9A00091822"
+            BuildableName = "PersistKit.framework"
+            BlueprintName = "PersistKit"
+            ReferencedContainer = "container:PersistKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2253925621A2ED9A00091822"
+            BuildableName = "PersistKit.framework"
+            BlueprintName = "PersistKit"
+            ReferencedContainer = "container:PersistKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/PersistKit.xcodeproj/xcshareddata/xcschemes/PersistKitTests.xcscheme
+++ b/ios/PersistKit.xcodeproj/xcshareddata/xcschemes/PersistKitTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8A4E61ED225C9ADE00C4174A"
+               BuildableName = "PersistKitTests.xctest"
+               BlueprintName = "PersistKitTests"
+               ReferencedContainer = "container:PersistKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/PersistKit/Command.swift
+++ b/ios/PersistKit/Command.swift
@@ -6,5 +6,6 @@ public enum Command {
   case loadWithIDs(_ identifiers: [String])
   case save(_ record: Record)
   case delete(_ identifier: String)
+  case clearDatabase
 }
 

--- a/ios/PersistKit/Database.swift
+++ b/ios/PersistKit/Database.swift
@@ -52,4 +52,12 @@ public final class Database {
     }
     return count == 1
   }
+  
+  public func clearDatabase() throws {
+    _ = try driver.execute(.clearDatabase)
+  }
+  
+  public func deleteDatabase() throws {
+    try driver.deleteDatabase()
+  }
 }

--- a/ios/PersistKit/Driver.swift
+++ b/ios/PersistKit/Driver.swift
@@ -4,4 +4,6 @@ import SQLite3
 public protocol Driver {
   func query(_ command: Command) throws -> [Record]
   func execute(_ command: Command) throws -> Int
+  
+  func deleteDatabase() throws
 }

--- a/ios/PersistKit/Driver/SQLite3Driver.swift
+++ b/ios/PersistKit/Driver/SQLite3Driver.swift
@@ -7,15 +7,16 @@ public final class SQLite3Driver: Driver {
 
   static let transiantDestructor = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
   
-  let filename: String
+  let fileURL: URL
   let db: OpaquePointer
   
-  public init?(filename: String) {
+  public init?(databaseFileURL: URL) {
     var dbout: OpaquePointer? = nil
-    guard sqlite3_open(filename, &dbout) == SQLITE_OK else { return nil }
+    guard databaseFileURL.isFileURL &&
+      sqlite3_open(databaseFileURL.absoluteString, &dbout) == SQLITE_OK else { return nil }
     guard let dbptr = dbout else { return nil }
     
-    self.filename = filename
+    self.fileURL = databaseFileURL
     self.db = dbptr
     
     ensureInitialized()
@@ -151,6 +152,6 @@ public final class SQLite3Driver: Driver {
       sqlite3_close(self.db)
     }
     
-    try FileManager.default.removeItem(atPath: filename)
+    try FileManager.default.removeItem(at: fileURL)
   }
 }

--- a/ios/PersistKit/Driver/SQLite3Driver.swift
+++ b/ios/PersistKit/Driver/SQLite3Driver.swift
@@ -139,6 +139,18 @@ public final class SQLite3Driver: Driver {
       return UpsertStatement(record)
     case .delete(let identifier):
       return DeleteIdentifierStatement(identifier)
+    case .clearDatabase:
+      return DeleteAllStatement()
     }
+  }
+  
+  public func deleteDatabase() throws {
+    if #available(iOS 8.2, *) {
+      sqlite3_close_v2(self.db)
+    } else {
+      sqlite3_close(self.db)
+    }
+    
+    try FileManager.default.removeItem(atPath: filename)
   }
 }

--- a/ios/PersistKit/Statement.swift
+++ b/ios/PersistKit/Statement.swift
@@ -139,3 +139,15 @@ struct SelectAllStatement: Statement {
         return true
     }
 }
+
+
+struct DeleteAllStatement: Statement {
+    
+    let sql: String = """
+        DELETE FROM records;
+        """
+    
+    func bindTo(statement: OpaquePointer?) -> Bool {
+        return true
+    }
+}

--- a/ios/PersistKitTests/PersistKitTests.swift
+++ b/ios/PersistKitTests/PersistKitTests.swift
@@ -74,10 +74,10 @@ class PersistKitTests: XCTestCase {
     XCTAssertNoThrow(try database.deleteDatabase())
     XCTAssertFalse(FileManager.default.fileExists(atPath: databaseFileURL.path))
     
+    // Restore the database state
     guard let driver = SQLite3Driver(databaseFileURL: databaseFileURL) else {
       fatalError("failed to initialize SQLite3Driver for Database")
     }
-    
     database = Database(driver: driver)
   }
 }

--- a/ios/PersistKitTests/PersistKitTests.swift
+++ b/ios/PersistKitTests/PersistKitTests.swift
@@ -21,13 +21,14 @@ class PersistKitTests: XCTestCase {
     }
     
     database = Database(driver: driver)
+    try! database.clearDatabase()
     
     try! todos.forEach(database.save)
   }
   
   override func tearDown() {
+    XCTAssertNoThrow(try database.deleteDatabase())
     database = nil
-    try! FileManager.default.removeItem(at: databaseFileURL)
   }
   
   func testLoadAllData() throws {

--- a/ios/PersistKitTests/PersistKitTests.swift
+++ b/ios/PersistKitTests/PersistKitTests.swift
@@ -16,7 +16,7 @@ class PersistKitTests: XCTestCase {
   }()
   
   override func setUp() {
-    guard let driver = SQLite3Driver(filename: databaseFileURL.path) else {
+    guard let driver = SQLite3Driver(databaseFileURL: databaseFileURL) else {
       fatalError("failed to initialize SQLite3Driver for Database")
     }
     
@@ -67,6 +67,18 @@ class PersistKitTests: XCTestCase {
       XCTAssertEqual($1.title, "Todo \($0)")
       XCTAssertEqual($1.detail, "Todo Item number \($0)")
     })
+  }
+  
+  func testDeleteDatabase() throws {
+    XCTAssertTrue(FileManager.default.fileExists(atPath: databaseFileURL.path))
+    XCTAssertNoThrow(try database.deleteDatabase())
+    XCTAssertFalse(FileManager.default.fileExists(atPath: databaseFileURL.path))
+    
+    guard let driver = SQLite3Driver(databaseFileURL: databaseFileURL) else {
+      fatalError("failed to initialize SQLite3Driver for Database")
+    }
+    
+    database = Database(driver: driver)
   }
 }
 


### PR DESCRIPTION
Security is an important part of our service hence clearing and deleting are also important operations for the PersistKit

This PR introduces the clearDatabase and deleteDatabase methods in both iOS and Android implementation.

1. clearDatabase will run the query to delete all records in the database
2. deleteDatabase will delete the database file and also run the clearDatabase in case there is an issue on deleting the file