### PR TITLE
Refactor encrypt/decrypt data implemantion

### DIFF
--- a/android/app/src/main/java/co/omise/persister/MainActivity.kt
+++ b/android/app/src/main/java/co/omise/persister/MainActivity.kt
@@ -101,7 +101,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun reloadTodoItem(item: TodoItem) {
         background.execute {
-            val updatedItem: TodoItem = database.load(item.identifier)
+            val updatedItem: TodoItem = database.load(item.identifier) ?: return@execute
             handler.post {
                 adapter.updateItem(updatedItem)
             }


### PR DESCRIPTION
### OBJECTIVE

To replace from using fixed IV to use IV from **Cipher** instead.

### DESCRIPTION OF CHANGE

In this PR, when encrypting data will attach IV in the front of encrypted data. To decrypt data, the decrypt function will read IV from encrypted data and use IV to initial **Cipher**.

Also, changed from using **Cipher** to encrypt/decrypt directly to use **CipherInputStream/CipherOutputStream** to fix the issue `IllegalBlockSizeException`.